### PR TITLE
Add codex workspace opener CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,13 @@ The build script will:
 2. Copy the executables to the bin directory
 3. Create a config directory inside bin
 4. Copy all JSON files from the config directory to bin/config 
+## Codex Workspace Tool
+
+Launch a ChatGPT Codex workspace for a specific project and branch:
+
+```bash
+go run ./cmd/codex -project owner/repo -branch main
+```
+
+The command opens `https://chatgpt.com/codex/owner/repo?branch=main` in your default browser.
+

--- a/cmd/codex/main.go
+++ b/cmd/codex/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func main() {
+	project := flag.String("project", "", "Project in owner/repo format")
+	branch := flag.String("branch", "", "Branch name")
+	flag.Parse()
+
+	if *project == "" || *branch == "" {
+		fmt.Println("Usage: codex -project <owner/repo> -branch <branch>")
+		os.Exit(1)
+	}
+
+	workspaceURL := buildURL(*project, *branch)
+	if err := openBrowser(workspaceURL); err != nil {
+		fmt.Printf("Failed to open browser: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func buildURL(project, branch string) string {
+	segments := strings.Split(project, "/")
+	for i, s := range segments {
+		segments[i] = url.PathEscape(s)
+	}
+	p := strings.Join(segments, "/")
+	b := url.QueryEscape(branch)
+	return fmt.Sprintf("https://chatgpt.com/codex/%s?branch=%s", p, b)
+}
+
+func openBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	case "darwin":
+		cmd = exec.Command("open", url)
+	default:
+		return fmt.Errorf("unsupported platform")
+	}
+	return cmd.Start()
+}

--- a/cmd/codex/main_test.go
+++ b/cmd/codex/main_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+func TestBuildURL(t *testing.T) {
+	tests := []struct {
+		project string
+		branch  string
+		want    string
+	}{
+		{"my-project", "main", "https://chatgpt.com/codex/my-project?branch=main"},
+		{"danielsiegl/goplayground", "main", "https://chatgpt.com/codex/danielsiegl/goplayground?branch=main"},
+	}
+	for _, tt := range tests {
+		if got := buildURL(tt.project, tt.branch); got != tt.want {
+			t.Errorf("buildURL(%q, %q) = %q, want %q", tt.project, tt.branch, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `codex` command to open ChatGPT Codex workspace for a project and branch
- handle `owner/repo` project paths to avoid 404s
- document owner/repo usage and test URL builder

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890ad69b75c83229a30d3bfd22e29db